### PR TITLE
Move & update EventFlags example from docs repo

### DIFF
--- a/EventFlags/README.md
+++ b/EventFlags/README.md
@@ -1,0 +1,3 @@
+# EventFlags example
+
+EventFlags usage example for Mbed OS.

--- a/EventFlags/main.cpp
+++ b/EventFlags/main.cpp
@@ -1,0 +1,29 @@
+#include "mbed.h"
+
+#define SAMPLE_FLAG1 (1UL << 0)
+#define SAMPLE_FLAG2 (1UL << 9)
+
+EventFlags event_flags;
+
+void worker_thread_fun()
+{
+    printf("Waiting for any flag from 0x%08lx.\r\n", SAMPLE_FLAG1 | SAMPLE_FLAG2);
+    uint32_t flags_read = 0;
+    while (true) {
+        flags_read = event_flags.wait_any(SAMPLE_FLAG1 | SAMPLE_FLAG2);
+        printf("Got: 0x%08lx\r\n", flags_read);
+    }
+}
+
+int main()
+{
+    Thread worker_thread;
+    worker_thread.start(mbed::callback(worker_thread_fun));
+
+    while (true) {
+        wait(1.0);
+        event_flags.set(SAMPLE_FLAG1);
+        wait(0.5);
+        event_flags.set(SAMPLE_FLAG2);
+    }
+}

--- a/EventFlags/mbed-os.lib
+++ b/EventFlags/mbed-os.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/mbed-os/#c53d51fe9220728bf8ed27afe7afc1ecc3f6f5d7


### PR DESCRIPTION
Move the `EventFlags` example from https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/api/rtos/EventFlags.md and update the code.