### PR TITLE
Delete mbed-os.lib

### DIFF
--- a/CellularTCP/mbed-os.lib
+++ b/CellularTCP/mbed-os.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/mbed-os/#c53d51fe9220728bf8ed27afe7afc1ecc3f6f5d7


### PR DESCRIPTION
Delete file because example is outdated and no longer used in the docs.