### PR TITLE
Revert "Delete mbed-os.lib"

### DIFF
--- a/CellularTCP/mbed-os.lib
+++ b/CellularTCP/mbed-os.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/mbed-os/#c53d51fe9220728bf8ed27afe7afc1ecc3f6f5d7


### PR DESCRIPTION
Reverts ARMmbed/mbed-os-examples-docs_only#34

Revert because 5.11 still uses this.