### PR TITLE
Add code snippet for UnbufferedSerial and BufferedSerial API documentation

### DIFF
--- a/APIs_Drivers/BufferedSerial_echo/main.cpp
+++ b/APIs_Drivers/BufferedSerial_echo/main.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mbed.h"
+
+// Maximum number of element the application buffer can contain
+#define MAXIMUM_BUFFER_SIZE                                                  32
+
+// Create a DigitalOutput object to toggle an LED whenever data is received.
+static DigitalOut led(LED1);
+
+// Create a BufferedSerial object with a default baud rate.
+static BufferedSerial serial_port(USBTX, USBRX);
+
+int main(void) {
+    // Set desired properties (9600-8-N-1).
+    serial_port.set_baud(9600);
+    serial_port.set_format(
+        /* bits */ 8,
+        /* parity */ BufferedSerial::None,
+        /* stop bit */ 1
+    );
+
+    // Application buffer to receive the data
+    char buf[MAXIMUM_BUFFER_SIZE] = {0};
+
+    while (1) {
+        if (uint32_t num = serial_port.read(buf, sizeof(buf))) {
+            // Toggle the LED.
+            led = !led;
+
+            // Echo the input back to the terminal.
+            serial_port.write(buf, num);
+        }
+    }
+}

--- a/APIs_Drivers/BufferedSerial_printf/main.cpp
+++ b/APIs_Drivers/BufferedSerial_printf/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mbed.h"
+
+// Specify different pins to test printing on UART other than the console UART.
+#define TARGET_TX_PIN                                                     USBTX
+#define TARGET_RX_PIN                                                     USBRX
+
+// Create a BufferedSerial object to be used by the system I/O retarget code.
+static BufferedSerial serial_port(TARGET_TX_PIN, TARGET_RX_PIN, 9600);
+
+FileHandle *mbed::mbed_override_console(int fd) {
+    return &serial_port;
+}
+
+int main(void) {
+    // print to the console using the `serial_port` object.
+    printf(
+        "Mbed OS version %d.%d.%d\n",
+        MBED_MAJOR_VERSION,
+        MBED_MINOR_VERSION,
+        MBED_PATCH_VERSION
+    );
+}

--- a/APIs_Drivers/UnbufferedSerial/main.cpp
+++ b/APIs_Drivers/UnbufferedSerial/main.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mbed.h"
+
+// Create a DigitalOutput object to toggle an LED whenever data is received.
+static DigitalOut led(LED1);
+
+// Create a UnbufferedSerial object with a default baud rate.
+static UnbufferedSerial serial_port(USBTX, USBRX);
+
+void on_rx_interrupt() {
+    char c;
+
+    // Toggle the LED.
+    led = !led;
+
+    // Read the data to clear the receive interrupt.
+    if (serial_port.read(&c, 1)) {
+        // Echo the input back to the terminal.
+        serial_port.write(&c, 1);
+    }
+}
+
+int main(void) {
+    // Set desired properties (9600-8-N-1).
+    serial_port.baud(9600);
+    serial_port.format(
+        /* bits */ 8,
+        /* parity */ SerialBase::None,
+        /* stop bit */ 1
+    );
+
+    // Register a callback to process a Rx (receive) interrupt.
+    serial_port.attach(&on_rx_interrupt, SerialBase::RxIrq);
+}


### PR DESCRIPTION
The code snippets are to be referenced in the API documentation for the classes.
### Update https://github.com/ARMmbed/mbed-os-5-docs/pull/1220 after merging!