### PR TITLE
add RTOS examples

### DIFF
--- a/APIs_RTOS/Basic/README.md
+++ b/APIs_RTOS/Basic/README.md
@@ -1,4 +1,4 @@
-# Basic rtos example
+# RTOS example
 
 This example shows how to use RTOS threading mechanism.
 

--- a/APIs_RTOS/Basic/README.md
+++ b/APIs_RTOS/Basic/README.md
@@ -1,0 +1,4 @@
+# Basic rtos example
+
+This example shows how to use RTOS threading mechanism.
+

--- a/APIs_RTOS/Basic/main.cpp
+++ b/APIs_RTOS/Basic/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "mbed.h"
+
+DigitalOut led1(LED1);
+DigitalOut led2(LED2);
+Thread thread;
+
+void led2_thread()
+{
+    while (true) {
+        led2 = !led2;
+        ThisThread::sleep_for(1000);
+    }
+}
+
+int main()
+{
+    thread.start(led2_thread);
+
+    while (true) {
+        led1 = !led1;
+        ThisThread::sleep_for(500);
+    }
+}

--- a/APIs_RTOS/Flags/README.md
+++ b/APIs_RTOS/Flags/README.md
@@ -1,0 +1,4 @@
+# Flags example
+
+This example shows how to use Flags for threads communication.
+

--- a/APIs_RTOS/Flags/main.cpp
+++ b/APIs_RTOS/Flags/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "mbed.h"
+
+Thread thread;
+DigitalOut led(LED1);
+
+void led_thread()
+{
+    while (true) {
+        // Signal flags that are reported as event are automatically cleared.
+        ThisThread::flags_wait_any(0x1);
+        led = !led;
+    }
+}
+
+int main(void)
+{
+    thread.start(callback(led_thread));
+
+    while (true) {
+        ThisThread::sleep_for(1000);
+        thread.flags_set(0x1);
+    }
+}

--- a/APIs_RTOS/Isr/README.md
+++ b/APIs_RTOS/Isr/README.md
@@ -1,0 +1,4 @@
+# Isr example
+
+This example shows how to use various isr mechanisms in MbedOS.
+

--- a/APIs_RTOS/Isr/README.md
+++ b/APIs_RTOS/Isr/README.md
@@ -1,4 +1,4 @@
-# Isr example
+# ISR example
 
-This example shows how to use various isr mechanisms in MbedOS.
+This example shows how to use various ISR mechanisms in Mbed OS.
 

--- a/APIs_RTOS/Isr/main.cpp
+++ b/APIs_RTOS/Isr/main.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020 Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "mbed.h"
+
+Ticker ticker;
+Thread thread;
+Queue<const char *, 5> trail;
+
+// Since we're printing from multiple threads, we need a mutex
+Mutex print_lock;
+
+enum ExecutionTypes {
+    IDLE,
+    USER,
+    ISR
+};
+
+const char *ExecutionMessages[] = {
+    "the idle thread",
+    "a user thread",
+    "interrupt context"
+};
+
+void handler()
+{
+    // Check to see if we're in interrupt context
+    if (core_util_is_isr_active()) {
+        // Do not print since we're in interrupt context
+        trail.put(&(ExecutionMessages[ISR]));
+    } else {
+        // Safe to print since we're in a user thread
+        print_lock.lock();
+        printf("Starting user thread\r\n");
+        print_lock.unlock();
+        while (true) {
+            trail.put(&(ExecutionMessages[USER]));
+            ThisThread::sleep_for(500);
+        }
+    }
+}
+
+void custom_idle_function()
+{
+    // Custom idle behavior would go here
+    // We won't print here since the default idle thread's stack is too small
+    trail.put(&(ExecutionMessages[IDLE]));
+
+    // Switch back to the default idle behavior
+    Kernel::attach_idle_hook(NULL);
+}
+
+int main()
+{
+    printf("Starting execution example\r\n");
+
+    // Attach the custom idle thread function
+    Kernel::attach_idle_hook(custom_idle_function);
+
+    // Trigger the interrupt every 3 seconds
+    ticker.attach(handler, 3);
+
+    // Start the user thread
+    thread.start(handler);
+
+    // Get the past exectuion trail
+    while (true) {
+        osEvent evt = trail.get();
+        if (evt.status != osEventMessage) {
+            print_lock.lock();
+            printf("Failed to retrieve the execution trail (returned %02lx)\r\n", evt.status);
+            print_lock.unlock();
+        } else {
+            print_lock.lock();
+            printf("Execution was in %s\r\n", *(const char **)evt.value.v);
+            print_lock.unlock();
+        }
+    }
+}

--- a/APIs_RTOS/Mail/README.md
+++ b/APIs_RTOS/Mail/README.md
@@ -1,0 +1,4 @@
+# Mail example
+
+This example shows how to use Mail for threads communication.
+

--- a/APIs_RTOS/Mail/main.cpp
+++ b/APIs_RTOS/Mail/main.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "mbed.h"
+
+/* Mail */
+typedef struct {
+    float    voltage; /* AD result of measured voltage */
+    float    current; /* AD result of measured current */
+    uint32_t counter; /* A counter value               */
+} mail_t;
+
+Mail<mail_t, 16> mail_box;
+Thread thread;
+
+void send_thread(void)
+{
+    uint32_t i = 0;
+    while (true) {
+        i++; // fake data update
+        mail_t *mail = mail_box.alloc();
+        mail->voltage = (i * 0.1) * 33;
+        mail->current = (i * 0.1) * 11;
+        mail->counter = i;
+        mail_box.put(mail);
+        ThisThread::sleep_for(1000);
+    }
+}
+
+int main(void)
+{
+    thread.start(callback(send_thread));
+
+    while (true) {
+        osEvent evt = mail_box.get();
+        if (evt.status == osEventMail) {
+            mail_t *mail = (mail_t *)evt.value.p;
+            printf("\nVoltage: %.2f V\n\r", mail->voltage);
+            printf("Current: %.2f A\n\r", mail->current);
+            printf("Number of cycles: %lu\n\r", mail->counter);
+
+            mail_box.free(mail);
+        }
+    }
+}

--- a/APIs_RTOS/Mutex/README.md
+++ b/APIs_RTOS/Mutex/README.md
@@ -1,0 +1,4 @@
+# Mutex example
+
+This example shows how to use Mutex for threads synchronization.
+

--- a/APIs_RTOS/Mutex/main.cpp
+++ b/APIs_RTOS/Mutex/main.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "mbed.h"
+
+Mutex stdio_mutex;
+Thread t2;
+Thread t3;
+
+void notify(const char *name, int state)
+{
+    stdio_mutex.lock();
+    printf("%s: %d\n\r", name, state);
+    stdio_mutex.unlock();
+}
+
+void test_thread(void const *args)
+{
+    while (true) {
+        notify((const char *)args, 0);
+        ThisThread::sleep_for(1000);
+        notify((const char *)args, 1);
+        ThisThread::sleep_for(1000);
+    }
+}
+
+int main()
+{
+    t2.start(callback(test_thread, (void *)"Th 2"));
+    t3.start(callback(test_thread, (void *)"Th 3"));
+
+    test_thread((void *)"Th 1");
+}

--- a/APIs_RTOS/Semaphore/README.md
+++ b/APIs_RTOS/Semaphore/README.md
@@ -1,0 +1,4 @@
+# Semaphore example
+
+This example shows how to use Semaphore for threads synchronization.
+

--- a/APIs_RTOS/Semaphore/main.cpp
+++ b/APIs_RTOS/Semaphore/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "mbed.h"
+
+Semaphore one_slot(1);
+Thread t2;
+Thread t3;
+
+void test_thread(void const *name)
+{
+    while (true) {
+        one_slot.acquire();
+        printf("%s\n\r", (const char *)name);
+        ThisThread::sleep_for(1000);
+        one_slot.release();
+    }
+}
+
+int main(void)
+{
+    t2.start(callback(test_thread, (void *)"Th 2"));
+    t3.start(callback(test_thread, (void *)"Th 3"));
+
+    test_thread((void *)"Th 1");
+}

--- a/APIs_RTOS/Threading_with_callback/README.md
+++ b/APIs_RTOS/Threading_with_callback/README.md
@@ -1,0 +1,4 @@
+# Simple threading example with callback
+
+This example shows how to run thread using callbacks.
+

--- a/APIs_RTOS/Threading_with_callback/main.cpp
+++ b/APIs_RTOS/Threading_with_callback/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "mbed.h"
+
+Thread thread;
+DigitalOut led1(LED1);
+volatile bool running = true;
+
+// Blink function toggles the led in a long running loop
+void blink(DigitalOut *led)
+{
+    while (running) {
+        *led = !*led;
+        ThisThread::sleep_for(1000);
+    }
+}
+
+// Spawns a thread to run blink for 5 seconds
+int main()
+{
+    thread.start(callback(blink, &led1));
+    ThisThread::sleep_for(5000);
+    running = false;
+    thread.join();
+}


### PR DESCRIPTION
Move examples:
https://os.mbed.com/teams/mbed_example/code/rtos_basic/
https://os.mbed.com/teams/mbed_example/code/rtos_mail/
https://os.mbed.com/teams/mbed_example/code/rtos_mutex/
https://os.mbed.com/teams/mbed_example/code/rtos_signals/
https://os.mbed.com/teams/mbed_example/code/rtos_threading_with_callback/
https://os.mbed.com/teams/mbed_example/code/rtos_isr/
https://os.mbed.com/teams/mbed_example/code/rtos_semaphore/
to this repo

Update example code to latest API's

Docs update PR: https://github.com/ARMmbed/mbed-os-5-docs/pull/1240