### PR TITLE
add memory stats examples

### DIFF
--- a/APIs_Platform/Heap_Stats_ex_1/README.md
+++ b/APIs_Platform/Heap_Stats_ex_1/README.md
@@ -1,0 +1,4 @@
+# Heap stats example
+
+Example to demonstrate usage of heap stats
+

--- a/APIs_Platform/Heap_Stats_ex_1/main.cpp
+++ b/APIs_Platform/Heap_Stats_ex_1/main.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mbed.h"
+#include "mbed_stats.h"
+
+int main(void)
+{
+    mbed_stats_heap_t heap_stats;
+
+    printf("Starting heap stats example\r\n");
+    mbed_stats_heap_get(&heap_stats);
+    printf("Start; Current heap: %lu\n", heap_stats.current_size);
+    printf("Start; Max heap size: %lu\n", heap_stats.max_size);
+
+    printf("\nAllocating 1000 bytes\n");
+    void *allocation = malloc(1000);
+
+    mbed_stats_heap_get(&heap_stats);
+    printf("Post-Alloc; Current heap: %lu\n", heap_stats.current_size);
+    printf("Post-Alloc; Max heap size: %lu\n", heap_stats.max_size);
+
+    free(allocation);
+    printf("\nFreed 1000 bytes\n");
+
+    mbed_stats_heap_get(&heap_stats);
+    printf("Post-Free; Current heap: %lu\n", heap_stats.current_size);
+    printf("Post-Free; Max heap size: %lu\n", heap_stats.max_size);
+}

--- a/APIs_Platform/Heap_Stats_ex_1/mbed_app.json
+++ b/APIs_Platform/Heap_Stats_ex_1/mbed_app.json
@@ -1,0 +1,3 @@
+{
+    "macros": ["MBED_HEAP_STATS_ENABLED=1"]
+}

--- a/APIs_Platform/Stack_Stats_ex_1/README.md
+++ b/APIs_Platform/Stack_Stats_ex_1/README.md
@@ -1,0 +1,4 @@
+# Stack stats example
+
+Example to demonstrate usage of `mbed_stats_stack_get_each` API
+

--- a/APIs_Platform/Stack_Stats_ex_1/main.cpp
+++ b/APIs_Platform/Stack_Stats_ex_1/main.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020 Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mbed.h"
+#include "mbed_stats.h"
+
+int main(void)
+{
+    printf("Starting stack stats example\r\n");
+
+    int cnt = osThreadGetCount();
+    mbed_stats_stack_t *stats = (mbed_stats_stack_t *) malloc(cnt * sizeof(mbed_stats_stack_t));
+
+    if (stats) {
+        cnt = mbed_stats_stack_get_each(stats, cnt);
+        for (int i = 0; i < cnt; i++) {
+            printf("Thread: 0x%lx, Stack size: %u, Max stack: %u\r\n",
+                   stats[i].thread_id, stats[i].reserved_size, stats[i].max_size);
+        }
+        free(stats);
+    }
+}

--- a/APIs_Platform/Stack_Stats_ex_1/mbed_app.json
+++ b/APIs_Platform/Stack_Stats_ex_1/mbed_app.json
@@ -1,0 +1,3 @@
+{
+    "macros": ["MBED_STACK_STATS_ENABLED=1"]
+}


### PR DESCRIPTION
Move examples:
https://os.mbed.com/teams/mbed_example/code/stack_stats_example/
https://os.mbed.com/teams/mbed_example/code/heap_stats_example/
https://os.mbed.com/teams/mbed_example/code/memory_tracing_example/
to this repo

Update example code to latest API's

Docs update PR: https://github.com/ARMmbed/mbed-os-5-docs/pull/1262