### PR TITLE
Fix deprecated Timer and LowPowerTimer read() usages

### DIFF
--- a/APIs_Drivers/Timer_HelloWorld/main.cpp
+++ b/APIs_Drivers/Timer_HelloWorld/main.cpp
@@ -4,6 +4,7 @@
  */
 #include "mbed.h"
 
+using namespace std::chrono;
 
 Timer t;
 
@@ -12,5 +13,5 @@ int main()
     t.start();
     printf("Hello World!\n");
     t.stop();
-    printf("The time taken was %f seconds\n", t.read());
+    printf("The time taken was %llu milliseconds\n", duration_cast<milliseconds>(t.elapsed_time()).count());
 }

--- a/APIs_Drivers/lowpowerTimer_ex_1/main.cpp
+++ b/APIs_Drivers/lowpowerTimer_ex_1/main.cpp
@@ -5,6 +5,8 @@
 
 #include "mbed.h"
 
+using namespace std::chrono;
+
 LowPowerTimer t;
 
 int main()
@@ -12,5 +14,5 @@ int main()
     t.start();
     printf("Hello World!\n");
     t.stop();
-    printf("The time taken was %f seconds\n", t.read());
+    printf("The time taken was %llu milliseconds\n", duration_cast<milliseconds>(t.elapsed_time()).count());
 }


### PR DESCRIPTION
Thanks to feedbacks from the community, we update timer examples to use chrono values.
Also change to print integer milliseconds (~ order of 10ms) instead of seconds as the new API does not use floating points.