### PR TITLE
Add threading blinky example

### DIFF
--- a/APIs_RTOS/ThisThread_Blinky/README.md
+++ b/APIs_RTOS/ThisThread_Blinky/README.md
@@ -1,0 +1,3 @@
+# Getting started with the ThisThread API
+
+Example application showing usage of the class `ThisThread`, spawns a thread that toggles an LED for a period of time.

--- a/APIs_RTOS/ThisThread_Blinky/main.cpp
+++ b/APIs_RTOS/ThisThread_Blinky/main.cpp
@@ -1,0 +1,27 @@
+#include "mbed.h"
+#include "rtos.h"
+
+#define STOP_FLAG 1
+
+// Toggles LED
+void blink(DigitalOut *led)
+{
+    // Toggle the LED every second, until the STOP_FLAG is set
+    while (!ThisThread::flags_wait_any_for(STOP_FLAG, 1s)) {
+        *led = !*led;
+    }
+}
+
+// Creates a thread to toggle an LED for 5 seconds
+int main()
+{
+    Thread thread;
+    DigitalOut led1(LED1);
+    thread.start(callback(blink, &led1));
+    // Pause the main thread for 5 seconds
+    ThisThread::sleep_for(5s);
+    // Set the flag checked by the thread to stop the loop
+    thread.flags_set(STOP_FLAG);
+    // Wait for the thread to terminate
+    thread.join();
+}


### PR DESCRIPTION
For consistency, all snippets used in Mbed docs should be stored here. This moves source from https://github.com/ARMmbed/mbed-os-example-thisthread/. This snippet is referenced here: https://os.mbed.com/docs/mbed-os/v6.4/apis/thisthread.html.