### PR TITLE
Add AT command parser example to docs

### DIFF
--- a/APIs_Platform/AT_CmdParser/README.md
+++ b/APIs_Platform/AT_CmdParser/README.md
@@ -1,20 +1,20 @@
 ## ATCmdParser Example ##
 
-This is a example showing ATCmdParser usage with ESP8266 WiFi module.
+Example application showing usage of the `ATCmdParser` class with the ESP8266 WiFi module.
 
 The program retrieves the FW version of the ESP8266 module connected over UART using AT commands. 
 
 ##  Getting started
 
 1. Import the example
-2. Compile and generate binary   
-5. Open a serial console session with the target platform using the following parameters:
-    * **Baud rate:** 9600
-    * **Data bits:** 8
-    * **Stop bits:** 1
-    * **Parity:** None
- 6. Flash the target with the compiled binary. 
- 7. The serial console should display a similar output to below, indicating a successful AT communication:
+1. Compile and generate binary   
+1. Open a serial console session with the target platform using the following parameters:
+   * **Baud rate:** 9600
+   * **Data bits:** 8
+   * **Stop bits:** 1
+   * **Parity:** None
+1. Flash the target with the compiled binary. 
+1. The serial console should display a similar output to below, indicating a successful AT communication:
  ```
 ATCmdParser with ESP8266 example
 AT> AT+GMR

--- a/APIs_Platform/AT_CmdParser/README.md
+++ b/APIs_Platform/AT_CmdParser/README.md
@@ -1,36 +1,3 @@
 ## ATCmdParser Example ##
 
 Example application showing usage of the `ATCmdParser` class with the ESP8266 WiFi module.
-
-The program retrieves the FW version of the ESP8266 module connected over UART using AT commands. 
-
-##  Getting started
-
-1. Import the example
-1. Compile and generate binary   
-1. Open a serial console session with the target platform using the following parameters:
-   * **Baud rate:** 9600
-   * **Data bits:** 8
-   * **Stop bits:** 1
-   * **Parity:** None
-1. Flash the target with the compiled binary. 
-1. The serial console should display a similar output to below, indicating a successful AT communication:
- ```
-ATCmdParser with ESP8266 example
-AT> AT+GMR
-AT? SDK version:%*d%n
-AT< AT+GMR
-AT<
-AT< AT version:1.3.0.0(Jul 14 2016 18:54:01)
-AT= SDK version:2
-AT? OK%n
-AT< .0.0(656edbf)
-AT< compile time:Jul 19 2016 18:44:44
-AT= OK
-ATCmdParser: Retrieving FW version
-ATCmdParser: FW version: 2
-ATCmdParser: Retrieving FW version success
-Done
-
-```
-

--- a/APIs_Platform/AT_CmdParser/README.md
+++ b/APIs_Platform/AT_CmdParser/README.md
@@ -1,0 +1,36 @@
+## ATCmdParser Example ##
+
+This is a example showing ATCmdParser usage with ESP8266 WiFi module.
+
+The program retrieves the FW version of the ESP8266 module connected over UART using AT commands. 
+
+##  Getting started
+
+1. Import the example
+2. Compile and generate binary   
+5. Open a serial console session with the target platform using the following parameters:
+    * **Baud rate:** 9600
+    * **Data bits:** 8
+    * **Stop bits:** 1
+    * **Parity:** None
+ 6. Flash the target with the compiled binary. 
+ 7. The serial console should display a similar output to below, indicating a successful AT communication:
+ ```
+ATCmdParser with ESP8266 example
+AT> AT+GMR
+AT? SDK version:%*d%n
+AT< AT+GMR
+AT<
+AT< AT version:1.3.0.0(Jul 14 2016 18:54:01)
+AT= SDK version:2
+AT? OK%n
+AT< .0.0(656edbf)
+AT< compile time:Jul 19 2016 18:44:44
+AT= OK
+ATCmdParser: Retrieving FW version
+ATCmdParser: FW version: 2
+ATCmdParser: Retrieving FW version success
+Done
+
+```
+

--- a/APIs_Platform/AT_CmdParser/main.cpp
+++ b/APIs_Platform/AT_CmdParser/main.cpp
@@ -1,0 +1,43 @@
+/* ATCmdParser usage example
+ * Copyright (c) 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed.h"
+
+#define   ESP8266_DEFAULT_BAUD_RATE   115200
+
+int main()
+{
+    BufferedSerial *_serial;
+    ATCmdParser *_parser;
+
+    printf("\nATCmdParser with ESP8266 example");
+
+    _serial = new BufferedSerial(D1, D0, ESP8266_DEFAULT_BAUD_RATE);
+    _parser = new ATCmdParser(_serial, "\r\n");
+    _parser->debug_on(true);
+
+    //Now get the FW version number of ESP8266 by sending an AT command
+    printf("\nATCmdParser: Retrieving FW version");
+    _parser->send("AT+GMR");
+    int version;
+    if (_parser->recv("OK") && _parser->recv("SDK version:%d", &version)) {
+        printf("\nATCmdParser: FW version: %d", version);
+        printf("\nATCmdParser: Retrieving FW version successful");
+    } else {
+        printf("\nATCmdParser: Retrieving FW version failed");
+        return -1;
+    }
+}

--- a/APIs_USB/USBHID/main.cpp
+++ b/APIs_USB/USBHID/main.cpp
@@ -4,7 +4,7 @@
  */
 #include <stdio.h>
 #include "mbed.h"
-#include "drivers/USBHID.h"
+#include "USBHID.h"
 
 // Declare a USBHID device
 USBHID HID(8, 8, 0x1234, 0x0006, 0x0001, true);

--- a/APIs_USB/USBHID/main.cpp
+++ b/APIs_USB/USBHID/main.cpp
@@ -4,7 +4,7 @@
  */
 #include <stdio.h>
 #include "mbed.h"
-#include "USBHID.h"
+#include "usb/USBHID.h"
 
 // Declare a USBHID device
 USBHID HID(8, 8, 0x1234, 0x0006, 0x0001, true);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
For consistency, all snippets used in Mbed docs should be stored here. This moves source from https://github.com/ARMmbed/mbed-os-example-atcmdparser. The snippet is referenced here https://os.mbed.com/docs/mbed-os/v6.4/apis/atcmdparser.html. 
* Source builds but no hardware tests done as I don't have a compatible WiFi module for the snippet  

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    