### PR TITLE
fix Serial_echoback

### DIFF
--- a/Tutorials_SerialComm/Serial_EchoBack/main.cpp
+++ b/Tutorials_SerialComm/Serial_EchoBack/main.cpp
@@ -10,10 +10,10 @@ static BufferedSerial pc(USBTX, USBRX);
 int main()
 {
     char msg[] = "Echoes back to the screen anything you type\n";
-    char *buff = new char[1];
+    char buff;
     pc.write(msg, sizeof(msg));
     while (1) {
-        pc.read(buff, sizeof(buff));
-        pc.write(buff, sizeof(buff));
+        pc.read(&buff, 1);
+        pc.write(&buff, 1);
     }
 }


### PR DESCRIPTION
`sizeof(buff)` is `4` because buff is a `char*`.

Fixed by removing the unnecessary pointer construct.