### PR TITLE
Update Event/EventQueue snippets to mirror updates to the API changes

### DIFF
--- a/APIs_RTOS/EventQueue_ex_2/main.cpp
+++ b/APIs_RTOS/EventQueue_ex_2/main.cpp
@@ -4,7 +4,22 @@
  */
 #include "mbed_events.h"
 #include <stdio.h>
+using namespace std::chrono_literals;
 
+// In the example below there are 3 types of event callbacks
+// 1) Call the provided function immediately
+// 2) Call the provided function once (after the specified period)
+// 3) Call the provided function every specified period
+//
+// Expected output:
+//
+// called immediately
+// called every 1 seconds
+// called in 2 seconds
+// called every 1 seconds
+// called every 1 seconds
+//    ^ repeated forever
+//
 int main()
 {
     // creates a queue with the default size
@@ -12,8 +27,8 @@ int main()
 
     // events are simple callbacks
     queue.call(printf, "called immediately\n");
-    queue.call_in(2000, printf, "called in 2 seconds\n");
-    queue.call_every(1000, printf, "called every 1 seconds\n");
+    queue.call_in(2000ms, printf, "called in 2 seconds\n");
+    queue.call_every(1000ms, printf, "called every 1 seconds\n");
 
     // events are executed by the dispatch_forever method
     queue.dispatch_forever();

--- a/APIs_RTOS/EventQueue_ex_3/main.cpp
+++ b/APIs_RTOS/EventQueue_ex_3/main.cpp
@@ -4,11 +4,22 @@
  */
 #include "mbed_events.h"
 #include <stdio.h>
+using namespace std::chrono_literals;
 
 /**
 Event queues easily align with module boundaries, where internal state can be
 implicitly synchronized through event dispatch. Multiple modules can use
 independent event queues, but still be composed through the EventQueue::chain function.
+
+Note the call() methods in this example only dispatch once as no period is
+set and thus defaults to dispatch_once(). The ordering of the chaining dictates
+the order of the dispatching.
+
+Expected output:
+
+hello from a!
+hello from c!
+hello from b!
 **/
 
 int main()
@@ -30,5 +41,5 @@ int main()
 
     // Dispatching a will in turn dispatch b and c, printing hello from
     // all three queues
-    a.dispatch();
+    a.dispatch_forever();
 }

--- a/APIs_RTOS/Events_ex_1/main.cpp
+++ b/APIs_RTOS/Events_ex_1/main.cpp
@@ -7,40 +7,97 @@
 // Creates an event bound to the specified event queue
 EventQueue queue;
 void handler(int count);
-Event<void(int)> event(&queue, handler);
+Event<void(int)> event1(&queue, handler);
+Event<void(int)> event2(&queue, handler);
+
 
 void handler(int count)
 {
-    printf("Event = %d \n", count);
+    unsigned time_ms = equeue_tick();
+    printf("Timestamp = %d Event = %d \n", time_ms, count);
     return;
 }
 
 void post_events(void)
 {
-
     // Events can be posted multiple times and enqueue gracefully until
-    // the dispatch function is called.
-    event.post(1);
-    event.post(2);
-    event.post(3);
+    // the dispatch function is called. Each event will be processed
+    // subject to any delay and period specified. Each time an event has
+    // been dispatched it will be re-queued ready for the next dispatch
+    // period.
+    event1.post(1);      // Event1 with a value of 1
+    event1.post(2);      // Event1 with a value of 2
+    event1.post(3);      // Event1 with a value of 3
+
+    // Cancel the last event posted ie Event1 with a value of 3
+    event1.cancel();
+
+    event1.post(4);      // Event1 with a value of 4
+
+    event2.post(5);      // Event2 with a value of 5
+
 }
+
+
+// Example  demonstrates the following:
+// 1. Post 5 different events to a queue
+// 2. Configure the event delay and period for each
+// 3. Invoke the dispatcher to dispatch events for a specified period
+//
+//    | 100ms |    200ms    | 100ms | 100ms |    200ms     |
+//            ^             ^       ^       ^              ^
+//       Events 1,2,4       ^       ^       ^              ^
+//        dispatched        ^       ^       ^              ^
+//                          ^       ^       ^              ^
+//                   Events 1,2,4   ^       ^              ^
+//                    dispatched    ^       ^              ^
+//                                  ^       ^              ^
+//                               Event 5    ^              ^
+//                                          ^              ^
+//                                      Event 1,2,4        ^
+//                                       dispatched        ^
+//                                                         ^
+//                                                       Events 1,2,4
+//                                                        dispatched
+//
+// Expected Output
+//
+// Timestamp = 100 Event = 1
+// Timestamp = 127 Event = 2
+// Timestamp = 156 Event = 4
+// Timestamp = 300 Event = 1
+// Timestamp = 327 Event = 2
+// Timestamp = 356 Event = 4
+// Timestamp = 400 Event = 5
+// Timestamp = 500 Event = 1
+// Timestamp = 527 Event = 2
+// Timestamp = 556 Event = 4
+// Timestamp = 700 Event = 1
+// Timestamp = 727 Event = 2
+// Timestamp = 756 Event = 4
 
 int main()
 {
-
+    // Example 1 Dispatch posted events for a specified period
     Thread event_thread;
 
     // The event can be manually configured for special timing requirements
-    // specified in milliseconds
-    event.delay(100);       // Starting delay - 100 msec
-    event.period(200);      // Delay between each evet - 200msec
+    // specified in milliseconds (using Chrono durations)
+    event1.delay(100ms);       // Starting delay - 100 msec
+    event1.period(200ms);      // Delay between each event - 200msec
+
+    event2.delay(400ms);           // Starting delay - 400 msec
+    event2.period(non_periodic);   // Single non periodic event
 
     event_thread.start(callback(post_events));
 
     // Posted events are dispatched in the context of the queue's
-    // dispatch function
-    queue.dispatch(400);        // Dispatch time - 400msec
-    // 400 msec - Only 2 set of events will be dispatched as period is 200 msec
+    // dispatch function. Note that the EventQueue library has yet to be
+    // converted to using Chrono times and thus times are still specified
+    // in integer millisecond units.
+    // 800 ms will allow the posted events to be dispatched multiple times
+    queue.dispatch(800);
 
     event_thread.join();
+
 }

--- a/APIs_RTOS/Events_ex_1/main.cpp
+++ b/APIs_RTOS/Events_ex_1/main.cpp
@@ -96,7 +96,7 @@ int main()
     // converted to using Chrono times and thus times are still specified
     // in integer millisecond units.
     // 800 ms will allow the posted events to be dispatched multiple times
-    queue.dispatch(800);
+    queue.dispatch_for(800ms);
 
     event_thread.join();
 

--- a/APIs_RTOS/UserAllocatedEvent_ex_1/main.cpp
+++ b/APIs_RTOS/UserAllocatedEvent_ex_1/main.cpp
@@ -70,8 +70,8 @@ int main()
     printf("*** start ***\n");
     Thread event_thread;
 
-    // The event can be manually configured for special timing requirements
-    // specified in milliseconds
+    // The event can be manually configured for special timing requirements.
+    // Timings are specified in milliseconds.
     // Starting delay - 100 msec
     // Delay between each event - 200msec
     event1.delay(100);
@@ -86,7 +86,7 @@ int main()
     event_thread.start(callback(post_events));
 
     // Posted events are dispatched in the context of the queue's dispatch function
-    queue.dispatch(400);        // Dispatch time - 400msec
+    queue.dispatch_for(400ms);        // Dispatch time - 400msec
     // 400 msec - Only 2 set of events will be dispatched as period is 200 msec
 
     event_thread.join();


### PR DESCRIPTION
https://github.com/ARMmbed/mbed-os/pull/13975 updates the EventQueue dispatch API to 
1) move it to using chrono times and bring it inline with the rest of the code
2) Separates the API into 3 distinct functions
    a) dispatch_for(duration ms)
    b) dispatch_once()
    c) dispatch_forever()

This PR updates the example snippets to mirror this functionality.