### PR TITLE
Update Arduino pin names

### DIFF
--- a/APIs_Drivers/AnalogIn_ex_1/main.cpp
+++ b/APIs_Drivers/AnalogIn_ex_1/main.cpp
@@ -5,8 +5,8 @@
 
 #include "mbed.h"
 
-AnalogIn position(A0);
-PwmOut servo(D3);
+AnalogIn position(ARDUINO_UNO_A0);
+PwmOut servo(ARDUINO_UNO_D3);
 
 int main()
 {

--- a/APIs_Drivers/AnalogIn_ex_2/main.cpp
+++ b/APIs_Drivers/AnalogIn_ex_2/main.cpp
@@ -5,7 +5,7 @@
 
 #include "mbed.h"
 
-AnalogIn input(A0);
+AnalogIn input(ARDUINO_UNO_A0);
 
 #define NUM_SAMPLES 1024
 

--- a/APIs_Drivers/AnalogIn_ex_3/main.cpp
+++ b/APIs_Drivers/AnalogIn_ex_3/main.cpp
@@ -6,7 +6,7 @@
 #include "mbed.h"
 
 // Initialize a pins to perform analog input and digital output functions
-AnalogIn   ain(A0);
+AnalogIn   ain(ARDUINO_UNO_A0);
 DigitalOut dout(LED1);
 
 int main(void)

--- a/APIs_Drivers/AnalogOut_ex_1/main.cpp
+++ b/APIs_Drivers/AnalogOut_ex_1/main.cpp
@@ -11,7 +11,7 @@ const double offset = 65535 / 2;
 
 // The sinewave is created on this pin
 // Adjust analog output pin name to your board spec.
-AnalogOut aout(A5);
+AnalogOut aout(ARDUINO_UNO_A5);
 
 int main()
 {

--- a/APIs_Drivers/AnalogOut_ex_2/main.cpp
+++ b/APIs_Drivers/AnalogOut_ex_2/main.cpp
@@ -7,7 +7,7 @@
 
 // Initialize a pins to perform analog and digital output functions
 // Adjust analog output pin name to your board spec.
-AnalogOut  aout(A5);
+AnalogOut  aout(ARDUINO_UNO_A5);
 DigitalOut dout(LED1);
 
 int main(void)

--- a/APIs_Drivers/BusInOut_ex_1/main.cpp
+++ b/APIs_Drivers/BusInOut_ex_1/main.cpp
@@ -5,7 +5,7 @@
 
 #include "mbed.h"
 
-BusInOut pins(D0, D1, D2); // Change these pins to buttons on your board.
+BusInOut pins(ARDUINO_UNO_D0, ARDUINO_UNO_D1, ARDUINO_UNO_D2); // Change these pins to buttons on your board.
 
 int main()
 {

--- a/APIs_Drivers/BusIn_ex_1/main.cpp
+++ b/APIs_Drivers/BusIn_ex_1/main.cpp
@@ -5,7 +5,7 @@
 
 #include "mbed.h"
 
-BusIn nibble(D0, D1, D2, D3); // Change these pins to buttons on your board.
+BusIn nibble(ARDUINO_UNO_D0, ARDUINO_UNO_D1, ARDUINO_UNO_D2, ARDUINO_UNO_D3); // Change these pins to buttons on your board.
 
 int main()
 {

--- a/APIs_Drivers/DigitalIn_ex_2/main.cpp
+++ b/APIs_Drivers/DigitalIn_ex_2/main.cpp
@@ -5,8 +5,8 @@
 
 #include "mbed.h"
 
-DigitalIn a(D0);
-DigitalIn b(D1);
+DigitalIn a(ARDUINO_UNO_D0);
+DigitalIn b(ARDUINO_UNO_D1);
 DigitalOut z_not(LED1);
 DigitalOut z_and(LED2);
 DigitalOut z_or(LED3);

--- a/APIs_Drivers/I2CSlave/main.cpp
+++ b/APIs_Drivers/I2CSlave/main.cpp
@@ -8,7 +8,7 @@
 #error [NOT_SUPPORTED] I2C Slave is not supported
 #endif
 
-I2CSlave slave(D14, D15);
+I2CSlave slave(ARDUINO_UNO_D14, ARDUINO_UNO_D15);
 
 int main()
 {

--- a/APIs_Drivers/SPISlave/main.cpp
+++ b/APIs_Drivers/SPISlave/main.cpp
@@ -4,7 +4,7 @@
  */
 #include "mbed.h"
 
-SPISlave device(D12, D11, D13, D10); // mosi, miso, sclk, ssel
+SPISlave device(ARDUINO_UNO_D12, ARDUINO_UNO_D11, ARDUINO_UNO_D13, ARDUINO_UNO_D10); // mosi, miso, sclk, ssel
 
 int main()
 {

--- a/APIs_Drivers/SPI_HelloWorld/main.cpp
+++ b/APIs_Drivers/SPI_HelloWorld/main.cpp
@@ -4,8 +4,8 @@
  */
 #include "mbed.h"
 
-SPI spi(D11, D12, D13); // mosi, miso, sclk
-DigitalOut cs(D0);
+SPI spi(ARDUINO_UNO_D11, ARDUINO_UNO_D12, ARDUINO_UNO_D13); // mosi, miso, sclk
+DigitalOut cs(ARDUINO_UNO_D0);
 
 int main()
 {

--- a/APIs_NFC/NFCController/main.cpp
+++ b/APIs_NFC/NFCController/main.cpp
@@ -12,7 +12,7 @@ static uint8_t ndef_buffer[1024] = {0};
 
 int main()
 {
-    mbed::nfc::PN512SPITransportDriver pn512_transport(D11, D12, D13, D10, A1, A0);
+    mbed::nfc::PN512SPITransportDriver pn512_transport(ARDUINO_UNO_D11, ARDUINO_UNO_D12, ARDUINO_UNO_D13, ARDUINO_UNO_D10, ARDUINO_UNO_A1, ARDUINO_UNO_A0);
     mbed::nfc::PN512Driver pn512_driver(&pn512_transport);
     events::EventQueue queue;
     mbed::nfc::NFCController nfc(&pn512_driver, &queue, ndef_buffer);

--- a/APIs_NFC/NFC_EEPROM/main.cpp
+++ b/APIs_NFC/NFC_EEPROM/main.cpp
@@ -12,7 +12,7 @@ static uint8_t ndef_buffer[1024] = {0};
 
 int main()
 {
-    mbed::nfc::vendor::ST::M24srDriver m24sr_driver(D14, D15);
+    mbed::nfc::vendor::ST::M24srDriver m24sr_driver(ARDUINO_UNO_D14, ARDUINO_UNO_D15);
     events::EventQueue queue;
     mbed::nfc::NFCEEPROM nfc(&m24sr_driver, &queue, ndef_buffer);
 

--- a/APIs_NetworkSocket/TCPSocketWiFi/main.cpp
+++ b/APIs_NetworkSocket/TCPSocketWiFi/main.cpp
@@ -13,7 +13,7 @@ OdinWiFiInterface wifi;
 #error [NOT_SUPPORTED] Only Arduino form factor devices are supported at this time
 #endif
 #include "ESP8266Interface.h"
-ESP8266Interface wifi(D1, D0);
+ESP8266Interface wifi(ARDUINO_UNO_D1, ARDUINO_UNO_D0);
 #endif
 
 const char *sec2str(nsapi_security_t sec)

--- a/APIs_Platform/AT_CmdParser/main.cpp
+++ b/APIs_Platform/AT_CmdParser/main.cpp
@@ -25,7 +25,7 @@ int main()
 
     printf("\nATCmdParser with ESP8266 example");
 
-    _serial = new BufferedSerial(D1, D0, ESP8266_DEFAULT_BAUD_RATE);
+    _serial = new BufferedSerial(ARDUINO_UNO_D1, ARDUINO_UNO_D0, ESP8266_DEFAULT_BAUD_RATE);
     _parser = new ATCmdParser(_serial, "\r\n");
     _parser->debug_on(true);
 

--- a/APIs_Platform/Callback_SerialPassthrough/main.cpp
+++ b/APIs_Platform/Callback_SerialPassthrough/main.cpp
@@ -6,7 +6,7 @@
 #include "mbed.h"
 
 static UnbufferedSerial pc(USBTX, USBRX);
-static UnbufferedSerial uart(D1, D0);
+static UnbufferedSerial uart(ARDUINO_UNO_D1, ARDUINO_UNO_D0);
 DigitalOut led1(LED1);
 DigitalOut led4(LED4);
 char *pc2uart = new char[1];

--- a/APIs_Platform/Poll/README.md
+++ b/APIs_Platform/Poll/README.md
@@ -7,8 +7,8 @@ The example transfers bidirectional data between two serial ports, acting as a v
 ```
 {
     "config": {
-        "UART1_TX": "D1",
-        "UART1_RX": "D0",
+        "UART1_TX": "ARDUINO_UNO_D1",
+        "UART1_RX": "ARDUINO_UNO_D0",
         "UART2_TX": "USBTX",
         "UART2_RX": "USBRX"
     }

--- a/APIs_Platform/Poll/mbed_app.json
+++ b/APIs_Platform/Poll/mbed_app.json
@@ -1,7 +1,7 @@
 {
     "config": {
-        "UART1_TX": "D1",
-        "UART1_RX": "D0",
+        "UART1_TX": "ARDUINO_UNO_D1",
+        "UART1_RX": "ARDUINO_UNO_D0",
         "UART2_TX": "USBTX",
         "UART2_RX": "USBRX"
     }

--- a/APIs_RTOS/Sonar/main.cpp
+++ b/APIs_RTOS/Sonar/main.cpp
@@ -101,7 +101,7 @@ public:
 int main()
 {
     // Create sonar object on pins D5 and D6
-    Sonar sonar(D5, D6);
+    Sonar sonar(ARDUINO_UNO_D5, ARDUINO_UNO_D6);
     // Begin background thread sonar acquires
     sonar.start();
 

--- a/APIs_USB/USBMouse_joystick/main.cpp
+++ b/APIs_USB/USBMouse_joystick/main.cpp
@@ -7,8 +7,8 @@
 
 USBMouse mouse;
 // x and y axis of the joystick
-AnalogIn   ainx(A0);
-AnalogIn   ainy(A1);
+AnalogIn   ainx(ARDUINO_UNO_A0);
+AnalogIn   ainy(ARDUINO_UNO_A1);
 int16_t a_inx;
 int16_t a_iny;
 

--- a/Tutorials_SerialComm/Serial_PassCharacters/main.cpp
+++ b/Tutorials_SerialComm/Serial_PassCharacters/main.cpp
@@ -6,7 +6,7 @@
 #include "mbed.h"
 
 static BufferedSerial pc(USBTX, USBRX);
-static BufferedSerial uart(D1, D0);
+static BufferedSerial uart(ARDUINO_UNO_D1, ARDUINO_UNO_D0);
 
 DigitalOut pc_activity(LED1);
 DigitalOut uart_activity(LED2);

--- a/Tutorials_UsingAPIs/Alarm/main.cpp
+++ b/Tutorials_UsingAPIs/Alarm/main.cpp
@@ -9,7 +9,7 @@
 #define MINUTE 60
 
 // Globals
-DigitalOut alarm_out(D2, 0);
+DigitalOut alarm_out(ARDUINO_UNO_D2, 0);
 DigitalOut alarm_led(LED_RED, 1);
 DigitalOut hour_led(LED_GREEN, 1);
 DigitalOut min_led(LED_BLUE, 1);

--- a/test.json
+++ b/test.json
@@ -1,7 +1,7 @@
 {
     "config": {
-        "UART1_TX": "D1",
-        "UART1_RX": "D0",
+        "UART1_TX": "ARDUINO_UNO_D1",
+        "UART1_RX": "ARDUINO_UNO_D0",
         "UART2_TX": "USBTX",
         "UART2_RX": "USBRX",
         "wifi-ssid": {
@@ -33,10 +33,10 @@
         },
         "K64F":{
             "target.components_add" : ["SPIF"],
-            "spif-driver.SPI_MOSI"  : "D11", 
-            "spif-driver.SPI_MISO"  : "D12",
-            "spif-driver.SPI_CLK"   : "D13",
-            "spif-driver.SPI_CS"    : "D10",
+            "spif-driver.SPI_MOSI"  : "ARDUINO_UNO_D11", 
+            "spif-driver.SPI_MISO"  : "ARDUINO_UNO_D12",
+            "spif-driver.SPI_CLK"   : "ARDUINO_UNO_D13",
+            "spif-driver.SPI_CS"    : "ARDUINO_UNO_D10",
             "target.components_add": ["DATAFLASH"]
         }
     }


### PR DESCRIPTION
This PR updates all examples to use the new Arduino pin names (e.g. D0 -> ARDUINO_UNO_D0).