### PR TITLE
fix typo in EventQueue_ex_1/main.cpp

### DIFF
--- a/APIs_RTOS/EventQueue_ex_1/main.cpp
+++ b/APIs_RTOS/EventQueue_ex_1/main.cpp
@@ -19,7 +19,7 @@ void rise_handler(void)
 
 void fall_handler(void)
 {
-    printf("rise_handler in context %p\n", ThisThread::get_id());
+    printf("fall_handler in context %p\n", ThisThread::get_id());
     // Toggle LED
     led1 = !led1;
 }


### PR DESCRIPTION
`void fall_handler(void)` should prints `fall_handler` not `rise_handler`